### PR TITLE
feat(factory): parameterize task-start script

### DIFF
--- a/factory/scripts/start_task.sh
+++ b/factory/scripts/start_task.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 # factory/scripts/start_task.sh
 #
-# WHY:  Handles starting a new feature branch safely and interactively.
-# WHAT: Checks for uncommitted changes, interactively builds a conventional
-#       branch name, and then creates it.
+# WHY:  Handles starting a new feature branch safely.
+# WHAT: Supports both interactive and parameterized branch creation.
+#       - Interactive: `task task-start`
+#       - Parameterized: `task task-start -- <type> <scope> <description>`
 
 set -e
 
 # --- Phase 1: State Verification ---
 STASH_PERFORMED=false
-if ! git diff --quiet --exit-code; then
+# Check for uncommitted changes, but only if not running in a CI environment
+if [ -z "$CI" ] && ! git diff --quiet --exit-code; then
   gum style --border normal --margin "1" --padding "1 2" --border-foreground 212 "⚠️ You have uncommitted changes."
   if gum confirm "Stash them and bring them to the new branch?"; then
     git stash
@@ -21,20 +23,27 @@ if ! git diff --quiet --exit-code; then
   fi
 fi
 
-# --- Phase 2: Interactive Branch Creation ---
-gum style --border normal --margin "1" --padding "1 2" --border-foreground 212 "🌿 Let's create a new branch."
+# --- Phase 2: Branch Creation (Interactive or Parameterized) ---
+BRANCH_TYPE=$1
+PBI_ID=$2
+DESCRIPTION=$3
 
-echo "Select a branch type:"
-BRANCH_TYPE=$(gum choose "feature" "fix" "docs" "style" "refactor" "test" "chore" "factory")
-if [ -z "$BRANCH_TYPE" ]; then exit 1; fi
+# If arguments are not provided, enter interactive mode.
+if [ -z "$BRANCH_TYPE" ] || [ -z "$PBI_ID" ] || [ -z "$DESCRIPTION" ]; then
+  gum style --border normal --margin "1" --padding "1 2" --border-foreground 212 "🌿 Let's create a new branch."
 
-echo "Enter the PBI number or scope (e.g., SFB-003):"
-PBI_ID=$(gum input --placeholder "SFB-XXX")
-if [ -z "$PBI_ID" ]; then exit 1; fi
+  echo "Select a branch type:"
+  BRANCH_TYPE=$(gum choose "feature" "fix" "docs" "style" "refactor" "test" "chore" "factory")
+  if [ -z "$BRANCH_TYPE" ]; then exit 1; fi
 
-echo "Enter a short description (use-kebab-case):"
-DESCRIPTION=$(gum input --placeholder "implement-new-feature")
-if [ -z "$DESCRIPTION" ]; then exit 1; fi
+  echo "Enter the PBI number or scope (e.g., SFB-003):"
+  PBI_ID=$(gum input --placeholder "SFB-XXX")
+  if [ -z "$PBI_ID" ]; then exit 1; fi
+
+  echo "Enter a short description (use-kebab-case):"
+  DESCRIPTION=$(gum input --placeholder "implement-new-feature")
+  if [ -z "$DESCRIPTION" ]; then exit 1; fi
+fi
 
 BRANCH_NAME="${BRANCH_TYPE}/${PBI_ID}/${DESCRIPTION}"
 gum confirm "Create branch '$BRANCH_NAME'?" || exit 0


### PR DESCRIPTION
The 'start_task.sh' script is now enhanced to support both interactive and non-interactive (parameterized) execution.

If called with arguments ('task task-start -- <type> <scope> <desc>'), it will create the branch directly. If called with no arguments, it falls back to the interactive prompts.

This improves workflow efficiency and enables easier automation. This work partially fulfills the acceptance criteria for PBI-SFB-FACTORY-006.
